### PR TITLE
Add package config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# epscrapper
+
+Authenticated web endpoint collector powered by [Playwright](https://playwright.dev/).
+
+## Installation
+
+```bash
+pip install .
+```
+
+After installation the `epscrapper` command becomes available globally.
+
+## Usage
+
+```bash
+epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --save output.json
+```
+
+## Features
+
+- Uses Chromium via Playwright for full authentication flows.
+- Waits for redirect to your dashboard before capturing.
+- Collects DOM links and network requests.
+- Saves results as a structured JSON file.
+
+## Development
+
+To work on the project locally install in editable mode:
+
+```bash
+pip install -e .
+```
+
+You'll also need to install Playwright browsers once:
+
+```bash
+playwright install
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "epscrapper"
+version = "0.1.0"
+description = "Authenticated web endpoint collector"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "typer>=0.7",
+    "tldextract",
+    "rich",
+    "playwright",
+]
+
+[project.scripts]
+epscrapper = "epscrapper:app"
+
+[tool.setuptools]
+py-modules = ["epscrapper"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` to make the scraper installable with an `epscrapper` CLI
- document usage, installation and features in a new README

## Testing
- `python -m py_compile epscrapper.py`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0 due to 403 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b13e8a2198832787c49d32868acc12