### PR TITLE
feat: expand endpoint discovery and add crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --save output.json
 
 - Uses Chromium via Playwright for full authentication flows.
 - Waits for redirect to your dashboard before capturing.
-- Collects DOM links and network requests.
+- Captures DOM links and network requests across all visited pages.
+- Supports optional crawling of same-origin links with `--crawl` to uncover
+  endpoints beyond the initial dashboard.
+- Searches a wide range of HTML tags and attributes to minimize missed
+  resources.
 - Saves results as a structured JSON file.
 
 ## Development


### PR DESCRIPTION
## Summary
- broaden DOM parsing to include more resource tags and return links to crawl
- add page-level scraping helper and optional recursive crawling
- capture network requests from all context pages and document new features

## Testing
- `python -m py_compile epscrapper.py`
- ❌ `python epscrapper.py --help` *(missing dependencies: typer, tldextract, rich, playwright)*
- ⚠️ `pip install typer rich tldextract playwright` *(ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b140f6fecc832785065f6d4e409301