### PR TITLE
feat: support multiple output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ After installation the `epscrapper` command becomes available globally.
 ## Usage
 
 ```bash
-epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --save output.json
+epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --sJ output.json
 ```
+
+Use `--sP` to save as plaintext and `--sC` for CSV output.
 
 ## Features
 
@@ -36,7 +38,7 @@ epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --save output.json
   endpoints beyond the initial dashboard.
 - Searches a wide range of HTML tags and attributes to minimize missed
   resources.
-- Saves results as a structured JSON file.
+- Saves results as JSON, CSV, or plaintext files.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add --sP, --sJ, and --sC flags to save results in plaintext, JSON, or CSV
- update CLI help and README for new save options

## Testing
- `python -m py_compile epscrapper.py`
- `python epscrapper.py scrape --help` *(fails: No module named 'typer')*
- `pip install typer rich tldextract playwright` *(fails: Could not find a version that satisfies the requirement typer)*

------
https://chatgpt.com/codex/tasks/task_b_68b142de96ec8327b07d3e0fca4428b6