### PR TITLE
feat: allow scraping without login

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ clones it if the current installation isn't a git checkout.
 ## Usage
 
 ```bash
+# scrape a public dashboard
+epscrapper --dashboard DASHBOARD_URL --sJ output.json
+
+# scrape after authenticating through a login page
 epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --sJ output.json
 ```
 


### PR DESCRIPTION
## Summary
- make login optional so dashboards without authentication can be scraped directly
- document login-free usage

## Testing
- `python -m py_compile epscrapper.py`


------
https://chatgpt.com/codex/tasks/task_b_68b1477a36e08327bc5934ca325d1d70