### PR TITLE
Allow scrapes without save flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --sJ output.json
 
 # scrape and download JavaScript files
 epscrapper --dashboard DASHBOARD_URL --sJ output.json --js-dir js_files
+ 
+# show results on screen without saving
+epscrapper --dashboard DASHBOARD_URL
 ```
 
-Use `--sP` to save as plaintext and `--sC` for CSV output.
+Use `--sP` to save as plaintext and `--sC` for CSV output. If no save flags
+are provided, endpoints are printed to the console.
 
 ## Features
 

--- a/epscrapper.py
+++ b/epscrapper.py
@@ -148,8 +148,6 @@ def scrape(
     crawl: bool = typer.Option(False, "--crawl/--no-crawl", help="🧭 Crawl subpages recursively."),
     js_dir: Path = typer.Option(None, "--js-dir", help="📂 Directory to save JavaScript files."),
 ):
-    if not any([s_p, s_j, s_c]):
-        raise typer.BadParameter("Please provide at least one output file via --sP, --sJ, or --sC.")
     asyncio.run(
         run_scraper(
             login,
@@ -324,6 +322,9 @@ async def run_scraper(
             writer.writeheader()
             writer.writerows(unique_eps)
         outputs.append(str(s_c))
+    if not outputs:
+        for ep in unique_eps:
+            console.print(ep["url"])
     table = Table(title="Scrape Summary")
     table.add_column("Metric")
     table.add_column("Value", justify="right")


### PR DESCRIPTION
## Summary
- Permit running `scrape` without specifying `--sP`, `--sJ` or `--sC`
- Print collected endpoints to console when no save flags are provided
- Document optional save flags in README

## Testing
- `python -m py_compile epscrapper.py`


------
https://chatgpt.com/codex/tasks/task_b_68b187c1e31c8327b2806bb8840695f0