### PR TITLE
Remove js-dir option and associated logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ epscrapper --dashboard DASHBOARD_URL --sJ output.json
 # scrape after authenticating through a login page
 epscrapper --login LOGIN_URL --dashboard DASHBOARD_URL --sJ output.json
 
-# scrape and download JavaScript files
-epscrapper --dashboard DASHBOARD_URL --sJ output.json --js-dir js_files
- 
 # show results on screen without saving
 epscrapper --dashboard DASHBOARD_URL
 ```
@@ -59,7 +56,6 @@ are provided, endpoints are printed to the console.
 - Searches a wide range of HTML tags and attributes to minimize missed
   resources.
 - Saves results as JSON, CSV, or plaintext files.
-- Optionally downloads JavaScript files with `--js-dir`.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- remove `--js-dir` CLI option and related code
- update documentation to drop mention of JavaScript file saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b18bc009d48327ab20f75adbe6b258