### PR TITLE
Add missing pyee dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "tldextract",
     "rich",
     "playwright",
+    "pyee>=11",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add pyee to the project dependencies so Playwright can import it at runtime

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd2f3c55a48327a16efefb9e162cd3